### PR TITLE
Dynamic modules

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -22277,6 +22277,195 @@
         </emu-clause>
       </emu-clause>
 
+      <emu-clause id="sec-dynamic-module-records">
+        <h1>Dynamic Module Records</h1>
+
+        <p>A <dfn id="dynamicmodule-record">Dynamic Module Record</dfn> is used to represent information about a module that is defined programatically. Its fields contain digested information about the names that are exported by the module and its concrete methods use this digest to link, instantiate, and evaluate the module alongside other Abstract Module Records.</p>
+        
+        <p>Dependency cycles with Source Text Module Records are avoided since these modules can only export, and not import from other Abstract Module Records.</p>
+
+        <p>Dynamic Module Records support late export binding, in that export names are only validated after execution.</p>
+
+        <p>In addition to the fields, defined in <emu-xref href="#table-36"></emu-xref>, Dynamic Module Records have the additional fields listed in <emu-xref href="#table-X"></emu-xref>. Each of these fields is initially set in CreateDynamicModule.</p>
+
+        <emu-table id="table-X" caption="Additional Fields of Dynamic Module Records">
+          <table>
+            <tbody>
+            <tr>
+              <th>
+                Field Name
+              </th>
+              <th>
+                Value Type
+              </th>
+              <th>
+                Meaning
+              </th>
+            </tr>
+            <tr>
+              <td>
+                [[ExportNames]]
+              </td>
+              <td>
+                A string List of exported names.
+              </td>
+              <td>
+                The list of export bindings associated with this dynamic Module Record.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                [[EvaluationError]]
+              </td>
+              <td>
+                An abrupt completion | *undefined*
+              </td>
+              <td>
+                A completion of type ~throw~ representing the exception that occurred during evaluation.  *undefined* if no exception occurred or if [[Status]] is not `"evaluated"`.
+              </td>
+            </tr>
+            </tbody>
+          </table>
+        </emu-table>
+        
+        <emu-clause id="sec-createdynamicmodule" aoid="CreateDynamicModule">
+          <h1>CreateDynamicModule ( _realm_, _hostDefined_ )</h1>
+          <p>This method would be expected to be called by the host when constructing a Module Record in _HostResolveImportedModule_.</p>
+          <p>The abstract operation CreateDynamicModule with arguments _realm_, and _hostDefined_ creates a new Dynamic Module Record performing the following steps:</p>
+          <emu-alg>
+            1. Let _exportNames_ be a new empty List.
+            1. Return the Dynamic Module Record { [[Realm]]: _realm_, [[Environment]]: *undefined*, [[Namespace]]: *undefined*, [[Status]]: `"uninstantiated"`, [[ExportNames]]: _exportNames_, [[EvaluationError]]: *undefined*, [[HostDefined]]: _hostDefined_ }.
+          </emu-alg>
+        </emu-clause>
+
+        <p>The following definitions specify the required concrete methods for Dynamic Module Records.</p>
+
+        <emu-clause id="sec-getexportednames">
+          <h1>GetExportedNames ( _exportStarSet_ ) Concrete Method</h1>
+          <p>The GetExportedNames concrete method of a Dynamic Module Record implements the corresponding Module Record abstract method.</p>
+          <p>It performs the following steps:</p>
+          <emu-alg>
+            1. Let _module_ be this Dynamic Module Record.
+            1. Return _module_.[[exportNames]].
+          </emu-alg>
+        </emu-clause>
+  
+        <emu-clause id="sec-resolveexport">
+          <h1>ResolveExport ( _exportName_, _resolveSet_ ) Concrete Method</h1>
+          <p>The ResolveExport concrete method of a Dynamic Module Record implements the corresponding Module Record abstract method.</p>
+
+          <p>ResolveExport ensures that a binding is created for the dynamic Module Record, lazily creating a binding if needed.</p>
+
+          <p>This abstract method performs the following steps:</p>
+  
+          <emu-alg>
+            1. Let _module_ be this Dynamic Module Record.
+            1. Let _hasExistingExportBinding_ be set to *false*.
+            1. For each string _e_ in _module_.[[ExportNames]], do
+              1. If _e_ is equal to _exportName_ then,
+                1. Set _hasExistingExportBinding_ to *true*.
+            1. If _hasExistingExportBinding_ is *false* then,
+              1. Let _envRec_ be the Module Environment Record _module_.[[Environment]]
+              1. If _envRec_ does not already have a binding for _exportName_ then,
+                1. Perform _envRec_.CreateMutableBinding(_name_, *false*).
+              1. Add _exportName_ to the list _module_.[[ExportNames]].
+            1. Return ResolvedBinding Record { [[Module]]: _module_, [[BindingName]]: _exportName_ }.
+          </emu-alg>
+        </emu-clause>
+  
+        <emu-clause id="sec-moduledeclarationinstantiation">
+          <h1>Instantiate ( ) Concrete Method</h1>
+
+          <p>The Instantiate concrete method of a Dynamic Module Record implements the corresponding Module Record abstract method.</p>
+          <p>On success, Instantiate transitions this module's [[Status]] from `"uninstantiated"` to `"instantiated"`. On failure, an exception is thrown and this module's [[Status]] remains `"uninstantiated"`.</p>
+
+          <p>This abstract method performs the following steps:</p>
+
+          <emu-alg>
+            1. Let _module_ be this Dynamic Module Record.
+            1. Assert: _module_.[[Status]] is not `"instantiating"` or `"evaluating"`.
+            1. Let realm be module.[[Realm]].
+            1. Assert: realm is not undefined.
+            1. Let env be NewModuleEnvironment(realm.[[GlobalEnv]]).
+            1. Set _module_.[[Environment]] to _env_.
+            1. Set _module_.[[Status]] to `"instantiated"`.
+            1. Return *undefined*.
+          </emu-alg>
+        </emu-clause>
+  
+        <emu-clause id="sec-moduleevaluation">
+          <h1>Evaluate ( ) Concrete Method</h1>
+
+          <p>The Evaluate concrete method of a Dynamic Module Record implements the corresponding Module Record abstract method.</p>
+          <p>Evaluate transitions this module's [[Status]] from `"instantiated"` to `"evaluated"`.</p>
+
+          <p>If execution results in an exception, that exception is recorded in the [[EvaluationError]] field and rethrown by future invocations of Evaluate.</p>
+
+          <p>Evaluation of dynamic modules calls out to _HostEvaluateDynamicModule_, before finalising the export names of the dynamic modules. Any uninitialized export bindings throw a reference error at this stage.</p>
+
+          <p>This abstract method performs the following steps:</p>
+
+          <emu-alg>
+            1. Let _m_ be this Dynamic Module Record.
+            1. Assert: _m_.[[Status]] is `"instantiated"` or `"evaluated"`.
+            1. Set _m_.[[Status]] to `"evaluating"`.
+            1. Let _result_ be HostEvaluateDynamicModule(_m_, _m_.[[ExportedBindings]]).
+            1. If _result_ is an abrupt completion, then
+              1. Assert: _m_.[[Status]] is `"evaluating"`.
+              1. Set _m_.[[Status]] to `"evaluated"`.
+              1. Set _m_.[[EvaluationError]] to _result_.
+              1. Return _result_.
+            1. Let _n_ be the value of _m_.[[Namespace]].
+            1. If _n_ is not _undefined_ then,
+              1. Assert _n_ is a Module Namespace Exotic Object.
+              1. Let _envRec_ be the value of _module_.[[Environment]].
+              1. For each string _exportName_ in _m_.[[ExportNames]], do
+                1. Assert: _envRec_ has a binding for _exportName_.
+                1. If the binding for _exportName_ in _envRec_ is uninitialized then,
+                  1. Let _error_ be a *ReferenceError* exception.
+                  1. Set _m_.[[Status]] to `"evaluated"`.
+                  1. Set _m_.[[EvaluationError]] to _error_.
+                  1. Return _error_.
+                1. If _n_.[[Exports]] does not contain a value for _exportName_ then,
+                  1. Let _exports_ be the new List containing the same values as _n_.[[Exports]] with _exportName_ added in sort order of `Array.prototype.sort` with *undefined* as _comparefn_.
+                  1. Set _M_.[[Exports]] to _exports_.
+            1. Set _m_.[[Status]] to `"evaluated"`.
+            1. Assert: _m_.[[EvaluationError]] is *undefined*.
+            1. Return *undefined*.
+          </emu-alg>
+        </emu-clause>
+
+        <emu-clause id="sec-setdynamicexportbinding">
+          <h1>SetDynamicExportBinding ( _name_, _value_ ) Concrete Method</h1>
+          <p>The CreateDynamicExportBinding concrete method of a Dynamic Module Record implements the corresponding Module Record abstract method for a string _name_ and initialization value _value_.</p>
+          <emu-alg>
+            1. Let _envRec_ be the module Environment Record for which the method was invoked.
+            1. If _envRec_ has a binding for _name_ then,
+              1. If the binding for _name_ in _envRec_ has not been initialized then,
+                1. Perform _envRec_.InitializeBinding(_name_, _value_).
+              1. Otherwise,
+                1. Perform _envRec_.SetMutableBinding(_name_, _value_, *true*).
+            1. Otherwise,
+              1. Perform _envRec_.CreateMutableBinding(_name_, *false*).
+              1. Perform _envRec_.InitializeBinding(_name_, _value_).
+          </emu-alg>
+        </emu-clause>
+      </emu-clause>
+
+      <emu-clause id="sec-hostevaluatedynamicmodule" aoid="HostEvaluateDynamicModule">
+        <h1>Runtime Semantics: HostEvaluateDynamicModule ( _dynamicModule_ )</h1>
+        <p>HostEvaluateDynamicModule is an implementation-defined abstract operation that performs programmatic execution of a Dynamic Module Record, _dynamicModule_.</p>
+        <p>The implementation of HostEvaluateDynamicModule must conform to the following requirements:</p>
+        <ul>
+          <li>
+            HostEvaluateDynamicModule will call the SetDynamicExportBinding concrete method on the _dynamicModule_ to initialize the export bindings.
+          </li>
+          <li>
+            If there is an evaluation error, it must be thrown.
+          </li>
+        </ul>
+      </emu-clause>
+
       <emu-clause id="sec-hostresolveimportedmodule" aoid="HostResolveImportedModule">
         <h1>Runtime Semantics: HostResolveImportedModule ( _referencingModule_, _specifier_ )</h1>
         <p>HostResolveImportedModule is an implementation-defined abstract operation that provides the concrete Module Record subclass instance that corresponds to the |ModuleSpecifier| String, _specifier_, occurring within the context of the module represented by the Module Record _referencingModule_.</p>

--- a/spec.html
+++ b/spec.html
@@ -22360,15 +22360,12 @@
   
           <emu-alg>
             1. Let _module_ be this Dynamic Module Record.
-            1. Let _hasExistingExportBinding_ be set to *false*.
-            1. For each string _e_ in _module_.[[ExportNames]], do
-              1. If _e_ is equal to _exportName_ then,
-                1. Set _hasExistingExportBinding_ to *true*.
-            1. If _hasExistingExportBinding_ is *false* then,
+            1. Let _exportNames_ be _module_.[[ExportNames]].
+            1. If _exportNames_ does not contain _exportName_ then,
               1. Let _envRec_ be the Module Environment Record _module_.[[Environment]]
               1. If _envRec_ does not already have a binding for _exportName_ then,
-                1. Perform _envRec_.CreateMutableBinding(_name_, *false*).
-              1. Add _exportName_ to the list _module_.[[ExportNames]].
+                1. Perform ! _envRec_.CreateMutableBinding(_name_, *false*).
+              1. Append _exportName_ to the end of _exportNames_.
             1. Return ResolvedBinding Record { [[Module]]: _module_, [[BindingName]]: _exportName_ }.
           </emu-alg>
         </emu-clause>
@@ -22409,7 +22406,7 @@
             1. Let _m_ be this Dynamic Module Record.
             1. Assert: _m_.[[Status]] is `"instantiated"` or `"evaluated"`.
             1. Set _m_.[[Status]] to `"evaluating"`.
-            1. Let _result_ be HostEvaluateDynamicModule(_m_, _m_.[[ExportedBindings]]).
+            1. Let _result_ be HostEvaluateDynamicModule(_m_).
             1. If _result_ is an abrupt completion, then
               1. Assert: _m_.[[Status]] is `"evaluating"`.
               1. Set _m_.[[Status]] to `"evaluated"`.
@@ -22426,8 +22423,9 @@
                   1. Set _m_.[[Status]] to `"evaluated"`.
                   1. Set _m_.[[EvaluationError]] to _error_.
                   1. Return _error_.
-                1. If _n_.[[Exports]] does not contain a value for _exportName_ then,
-                  1. Add _exportName_ to _n_.[[Exports]] at the position corresponding to the sort order of `Array.prototype.sort` with *undefined* as _comparefn_.
+                1. Let _namespaceExports_ be _n_.[[Exports]].
+                1. If _namespaceExports_ does not contain _exportName_ then,
+                  1. Insert _exportName_ in the list _namespaceExports_ at the position corresponding to the sort order of `Array.prototype.sort` with *undefined* as _comparefn_.
             1. Set _m_.[[Status]] to `"evaluated"`.
             1. Assert: _m_.[[EvaluationError]] is *undefined*.
             1. Return *undefined*.
@@ -22438,7 +22436,8 @@
           <h1>SetDynamicExportBinding ( _name_, _value_ ) Concrete Method</h1>
           <p>The SetDynamicExportBinding concrete method of a Dynamic Module Record implements the corresponding Module Record abstract method for a string _name_ and initialization value _value_.</p>
           <emu-alg>
-            1. Let _envRec_ be the module Environment Record for which the method was invoked.
+            1. Let _module_ be this Dynamic Module Record.
+            1. Let _envRec_ be the module Environment Record _module_.[[Environment]].
             1. If _envRec_ has a binding for _name_ then,
               1. If the binding for _name_ in _envRec_ has not been initialized then,
                 1. Perform _envRec_.InitializeBinding(_name_, _value_).

--- a/spec.html
+++ b/spec.html
@@ -22384,9 +22384,9 @@
           <emu-alg>
             1. Let _module_ be this Dynamic Module Record.
             1. Assert: _module_.[[Status]] is not `"instantiating"` or `"evaluating"`.
-            1. Let realm be module.[[Realm]].
-            1. Assert: realm is not undefined.
-            1. Let env be NewModuleEnvironment(realm.[[GlobalEnv]]).
+            1. Let _realm_ be module.[[Realm]].
+            1. Assert: _realm_ is a valid Realm.
+            1. Let _env_ be NewModuleEnvironment(_realm_.[[GlobalEnv]]).
             1. Set _module_.[[Environment]] to _env_.
             1. Set _module_.[[Status]] to `"instantiated"`.
             1. Return *undefined*.
@@ -22427,8 +22427,7 @@
                   1. Set _m_.[[EvaluationError]] to _error_.
                   1. Return _error_.
                 1. If _n_.[[Exports]] does not contain a value for _exportName_ then,
-                  1. Let _exports_ be the new List containing the same values as _n_.[[Exports]] with _exportName_ added in sort order of `Array.prototype.sort` with *undefined* as _comparefn_.
-                  1. Set _M_.[[Exports]] to _exports_.
+                  1. Add _exportName_ to _n_.[[Exports]] at the position corresponding to the sort order of `Array.prototype.sort` with *undefined* as _comparefn_.
             1. Set _m_.[[Status]] to `"evaluated"`.
             1. Assert: _m_.[[EvaluationError]] is *undefined*.
             1. Return *undefined*.
@@ -22437,7 +22436,7 @@
 
         <emu-clause id="sec-setdynamicexportbinding">
           <h1>SetDynamicExportBinding ( _name_, _value_ ) Concrete Method</h1>
-          <p>The CreateDynamicExportBinding concrete method of a Dynamic Module Record implements the corresponding Module Record abstract method for a string _name_ and initialization value _value_.</p>
+          <p>The SetDynamicExportBinding concrete method of a Dynamic Module Record implements the corresponding Module Record abstract method for a string _name_ and initialization value _value_.</p>
           <emu-alg>
             1. Let _envRec_ be the module Environment Record for which the method was invoked.
             1. If _envRec_ has a binding for _name_ then,


### PR DESCRIPTION
This allows dynamic modules to be defined in the spec, which have certain features:

* They do not correspond to an ECMAScript module source text, but rather represent programmatic modules.
* They do not import other modules, but only export
* Their export bindings are not known and validated until execution time
* A new host hook HostEvaluateDynamicModule can then perform the execution of these programmatic modules, as well as initializing the export bindings.
* Any exported bindings not initialized after HostEvaluateDynamicModule throw reference errors then.